### PR TITLE
Make the doctype valid.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html public "i ♥ the web">
+<!doctype html>
 <!--[if lt IE 9]>      <html class="no-js oldie no-fontface" lang="en"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js no-fontface" lang="en">   <!--<![endif]-->
 <head>


### PR DESCRIPTION
Make the invalid doctype:

``` html
<!DOCTYPE html public "i ♥ the web">
```

valid. This is a pull request in response to the go a head given by @paulirish in [issue #32](https://github.com/h5bp/movethewebforward/issues/32). 
