### PR TITLE
Adding #dojo to IRC channels

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
             <h2 id="answer_questions_and_participate_in_conversations_on_irc" class="subhed">Answer questions and participate in conversations on IRC</h2>
             <p><a href="http://richard.esplins.org/siwi/2011/07/08/getting-started-freenode-irc/">How to get started with freenode and irc</a></p>
             <ul>
-              <li><b>Freenode IRC channels:</b> #html5 / #css / #javascript / #whatwg / #jquery / #yui (on <a href="http://webchat.freenode.net">irc.freenode.net</a>) </li>
+              <li><b>Freenode IRC channels:</b> #html5 / #css / #javascript / #whatwg / #jquery / #yui / #dojo (on <a href="http://webchat.freenode.net">irc.freenode.net</a>) </li>
               <li id="mozilla_irc"><b>Mozilla IRC channels:</b> #css / #js (on <a href="http://irc.mozilla.org">irc.mozilla.org</a>)</li>
             </ul>
 
@@ -171,7 +171,7 @@
               <li><a href="https://github.com/twitter/bootstrap">Twitter&#8217;s bootstrap</a> <span>- a css and js toolkit designed to kickstart development of webapps</span>
               <li><a href="http://necolas.github.com/normalize.css/">Normalize.css</a> <span>- make all browsers render markup the same</span>
               <li><a href="http://dojotoolkit.org/get-involved">Dojo</a> <span>- the comprehensive frontend app development toolkit</span>
-                <li><a href="https://github.com/paulirish/lazyweb-requests/issues?state=open">Lazyweb requests</a> <span>- Web tools and solutions that would be cool to have for web developers.</span>
+              <li><a href="https://github.com/paulirish/lazyweb-requests/issues?state=open">Lazyweb requests</a> <span>- Web tools and solutions that would be cool to have for web developers.</span>
               <li><a href="https://github.com/jquery/standards">jQuery standards project</a> <span>- issues and discussions relating to web standards</span>
               <li><a href="http://yuilibrary.com/">YUI</a> <span>- the Yahoo! User Interface Library</span></li>
             </ul>


### PR DESCRIPTION
Pretty simple/straightforward, just adding #dojo to the list of channels for help in IRC. That and a small whitespace thing I saw to be consistent. But mostly the #dojo bit.
