### PR TITLE
Replace broken MS links

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,24 +64,24 @@
                 <li><a href="http://peter.sh/">Peter Beverloo&#8217;s Blog</a> - weekly updates of WebKit and Chrome</li>
                 <li><a href="https://blog.whatwg.org/">The WHATWG Blog</a> - summaries of weekly web standards activity</li>
                 <li><a href="http://www.w3.org/QA/archive/open_web/">W3C&#8217;s open web</a> - weekly updates about the Open Web Platform</li>
-                <li><a href="https://dev.opera.com/blog/">Dev.Opera Blog</a> - tracks changes to Opera's web platform
+                <li><a href="https://dev.opera.com/blog/">Dev.Opera Blog</a> - tracks changes to Opera&#8217;s web platform
                 <li><a href="http://updates.html5rocks.com">HTML5 Rocks updates</a> - HTML5 and Chrome breaking news
 
                 <li><a href="https://hacks.mozilla.org/">Mozilla Hacks</a> - cool apps and HTML5 features
-                <li><a href="https://status.modern.ie">Status.Modern.IE</a> - IE web platform status and roadmap.
+                <li><a href="https://dev.modern.ie">Dev.Modern.IE</a> - Microsoft Edge web platform status and roadmap.
                 <li><a href="https://blog.chromium.org/">Chromium Blog</a> - tracks changes to Chromium and Chrome
               </ul>
 
               <h3 id="follow_them_on_twitter" class="subhed">Follow them on Twitter</h3>
                 <p>
-                  You should probably follow: <a href="https://twitter.com/oDevRel">@oDevRel</a> (Opera developer relations), <a href="https://twitter.com/ChromiumDev">@ChromiumDev</a> (Chrome developer relations), <a href="https://twitter.com/mozhacks">@mozhacks</a> (Mozilla's web developer outpost) & <a href="https://twitter.com/iedevchat">@IEDevChat</a> (Internet Explorer developer relations).
+                  You should probably follow: <a href="https://twitter.com/oDevRel">@oDevRel</a> (Opera developer relations), <a href="https://twitter.com/ChromiumDev">@ChromiumDev</a> (Chrome developer relations), <a href="https://twitter.com/mozhacks">@mozhacks</a> (Mozilla&#8217;s web developer outpost) & <a href="https://twitter.com/MSEdgeDev">@MSEdgeDev</a> (Microsoft Web Platform Team).
                 </p>
 
               <h2 id="how_do_i_understand_how_browsers_work" class="subhed">How do I understand how browsers work?</h2>
 
               <ul>
                 <li><a href="http://www.html5rocks.com/en/tutorials/internals/howbrowserswork/">How Browsers Work: Behind the Scenes of Modern Web Browsers</a> - in-depth look at how a browser works</li>
-                <li><a href="http://ontwik.com/?p=5215">Life of a &lt;button> element (by Alex Russell)</a> - great talk about rendering layout and CSS</li>
+                <li><a href="http://ontwik.com/?p=5215">Life of a &lt;button&gt; element (by Alex Russell)</a> - great talk about rendering layout and CSS</li>
               </ul>
 
               <h2 id="other_learning_resources" class="subhed">Other learning resources</h2>
@@ -94,7 +94,7 @@
                 <li><a href="http://addyosmani.com/blog/">Addy Osmani&#8217;s blog</a> - tons of great articles for people who want to learn more about jQuery, JavaScript, HTML5, and CSS3.</li>
                 <li><a href="http://paulirish.com">Paul Irish&#8217;s blog</a> - all about helping you build cool websites and keeping you up to date on the latest news.</li>
                 <li><a href="https://dev.opera.com">Dev.Opera</a> - articles for learning about HTML5 features.</li>
-                <li><a href="http://blogs.msdn.com/b/ie/">IE Blog</a> - talks about updates to Internet Explorer</li>
+                <li><a href="http://blogs.windows.com/msedgedev/">MS Edge Dev Blog</a> - talks about updates to Microsoft&#8217;s Edge browser</li>
                 <li><a href="http://paulirish.com/2011/web-browser-frontend-and-standards-feeds-to-follow/">Web browser, frontend and standards feeds to follow</a> </li>
                 <li><a href="http://yuilibrary.com/theater/">YUI Theater</a> - videos of talks about frontend engineering and web technologies given at Yahoo! over the years (many of them unrelated to YUI).</li>
                 <li><a href="http://www.adobe.com/devnet/html5.html">Adobe Developer Connection</a> - articles and videos for learning about HTML5, CSS3 and mobile development.</li>


### PR DESCRIPTION
The broken MS links are replaced by up-to-date ones, used correct apostrophes, & escaped an angle bracket for consistency. Mostly minor stuff.