### PR TITLE
Fix Mozilla broken link

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,7 +384,7 @@
             <li>Help build devtools, like the <a href="http://trac.webkit.org/wiki/WebInspector">WebKit Inspector</a>.
             They are written in HTML, CSS, and JS so you don&#8217;t need to be a C++ programmer to contribute to these.
             Write patches!</li>
-            <li><a href="https://developer.mozilla.org/en/Gecko_BugAThon">Reduce test cases for Mozilla</a></li>
+            <li><a href="https://developer.mozilla.org/en-US/docs/Mozilla/QA/Reducing_testcases">Reduce test cases for Mozilla</a></li>
             <li>Hack on Gecko
               <ul>
                 <li>Read the developer guide for <a href="https://developer.mozilla.org/En/Developer_Guide">getting started with Gecko development</a>.


### PR DESCRIPTION
This commit replaces the 'Reduce test cases for Mozilla' link
from the old MDN website to the new one. That's it. :)
